### PR TITLE
Allow multiple configurations passed to python::venv::isolate().

### DIFF
--- a/manifests/pip/requirements.pp
+++ b/manifests/pip/requirements.pp
@@ -41,7 +41,7 @@ define python::pip::requirements($venv, $owner=undef, $group=undef,
   exec { "update $name requirements":
     command => "$venv/bin/pip install -Ur $requirements",
     cwd => $venv,
-    timeout => 1800, # sometimes, this can take a while
+    timeout => 0, # sometimes, this can take a while
     require => File[$requirements],
     unless => "sha1sum -c $checksum",
     notify => Exec["create new checksum of $name requirements"],

--- a/manifests/pip/requirements.pp
+++ b/manifests/pip/requirements.pp
@@ -39,7 +39,7 @@ define python::pip::requirements($venv, $owner=undef, $group=undef,
   }
 
   exec { "update $name requirements":
-    command => "$venv/bin/pip install -Ur $requirements",
+    command => "$venv/bin/pip install -r $requirements",
     cwd => $venv,
     timeout => 0, # sometimes, this can take a while
     require => File[$requirements],

--- a/manifests/venv/isolate.pp
+++ b/manifests/venv/isolate.pp
@@ -1,11 +1,11 @@
 define python::venv::isolate($ensure=present,
                              $version=latest,
                              $requirements=undef,
-                             $requirements_source=undef) {
+                             $requirements_source=undef,
+                             $owner=$python::venv::owner,
+                             $group=$python::venv::group,
+                             $python=$python::dev::python) {
   $root = $name
-  $owner = $python::venv::owner
-  $group = $python::venv::group
-  $python = $python::dev::python
 
   if $ensure == 'present' {
     # Parent directory of root directory. /var/www for /var/www/blog
@@ -29,7 +29,7 @@ define python::venv::isolate($ensure=present,
     exec { "python::venv $root":
       command    => "virtualenv -p `which ${python}` ${root}",
       creates    => $root,
-      logoutput  => on_failure, 
+      logoutput  => on_failure,
       notify     => Exec["update distribute and pip in $root"],
       require    => [File[$root_parent],
                   Package["python-virtualenv"]],


### PR DESCRIPTION
The owner, group and python parameters are taken from the class config
only if they are not specified. This allows different virutal envs to
be defined in the same recipe file.
